### PR TITLE
Testes para verificação do componente CommerceInfo

### DIFF
--- a/cypress/integration/components/commerce-info.spec.js
+++ b/cypress/integration/components/commerce-info.spec.js
@@ -1,0 +1,30 @@
+describe("Testa comportamento do componente ProductCard", () => {
+    it("Retorna true se o componente está visível", () => {
+
+        cy.visit('/')
+
+        // Checa se o container do componente está visível
+        cy.get('.styles_container__6trCd').should('be.visible')
+
+        // Checa se o container da imagem está visível
+        cy.get('.styles_commerce_image__3bbwV').should('be.visible')
+
+        // Checa se o container da div de ícones de redes sociais está visível
+        cy.get('.styles_social_medias__U_Jbp').should('be.visible')
+
+        // Checa se o container do endereço está visível
+        cy.get('.styles_address__384Kd').should('be.visible')
+
+        // Checa se o container dos botões está visível
+        cy.get('.styles_buttons__2eZIf').should('be.visible')
+
+        // Clica no botão de horários, abre o modal e depois fecha
+        cy.get('.style_container__jFrh2:last').click()
+        cy.get('.style_outContainer__2GlHv').should('be.visible')
+        cy.get('.style_close__2Czx5').click()
+        cy.get('.style_outContainer__2GlHv').should('not.be.visible')
+
+        // Verifica se o atributo href existe na tag a
+        cy.get('.styles_buttons__2eZIf a').should('have.prop', 'href')
+    })
+})

--- a/cypress/integration/components/commerce-info.spec.js
+++ b/cypress/integration/components/commerce-info.spec.js
@@ -26,5 +26,7 @@ describe("Testa comportamento do componente ProductCard", () => {
 
         // Verifica se o atributo href existe na tag a
         cy.get('.styles_buttons__2eZIf a').should('have.prop', 'href')
+        // cy.get('.styles_buttons__2eZIf a').click()
+        // cy.url().then(url => console.log(url))
     })
 })

--- a/cypress/integration/components/commerce-info.spec.js
+++ b/cypress/integration/components/commerce-info.spec.js
@@ -1,5 +1,5 @@
 describe("Testa comportamento do componente ProductCard", () => {
-    it("Retorna true se o componente está visível", () => {
+    it("Testa se as divs estão visíveis", () => {
 
         cy.visit('/')
 
@@ -17,15 +17,22 @@ describe("Testa comportamento do componente ProductCard", () => {
 
         // Checa se o container dos botões está visível
         cy.get('.styles_buttons__2eZIf').should('be.visible')
+    })
+
+    it("Testa se o botão horários abre o modal", () => {
 
         // Clica no botão de horários, abre o modal e depois fecha
         cy.get('.style_container__jFrh2:last').click()
         cy.get('.style_outContainer__2GlHv').should('be.visible')
         cy.get('.style_close__2Czx5').click()
         cy.get('.style_outContainer__2GlHv').should('not.be.visible')
+    })
 
+    it("Testa se o botão de contato tem um href", () => {
         // Verifica se o atributo href existe na tag a
         cy.get('.styles_buttons__2eZIf a').should('have.prop', 'href')
+
+
         // cy.get('.styles_buttons__2eZIf a').click()
         // cy.url().then(url => console.log(url))
     })

--- a/cypress/integration/components/commerce-info.spec.js
+++ b/cypress/integration/components/commerce-info.spec.js
@@ -1,4 +1,4 @@
-describe("Testa comportamento do componente ProductCard", () => {
+describe("Testa comportamento do componente CommerceInfo", () => {
     it("Testa se as divs estão visíveis", () => {
 
         cy.visit('/')


### PR DESCRIPTION
- [x] Verificação se o container está visível
- [x] Verificação se a imagem está visível
- [x] Verificação se o nome está visível
- [x] Verificação se os ícones de mídias sociais estão visíveis
- [x] Verificação se os botões estão visíveis
- [x] Verificação se o botão de whatsapp contém um href
- [x] Verificação se o botão de horários abre o modal  


![Captura de tela de 2021-09-08 12-34-13](https://user-images.githubusercontent.com/50140883/132539946-bb98dd39-2323-4195-99f7-80948f2a33a0.png)
