### PR TITLE
Teste modalTimeListing

### DIFF
--- a/cypress/integration/components/modal-time-listing.spec.js
+++ b/cypress/integration/components/modal-time-listing.spec.js
@@ -1,0 +1,25 @@
+describe("Testa comportamento do componente ModalTimeListing", () => { 
+    it("Retorna true se o botão que dispara o componente está visível", () => {
+        
+        cy.visit('/')
+        
+        cy.get('.style_container__jFrh2').should('be.visible')
+        cy.get('.style_container__jFrh2').click().wait(3000)
+    })
+
+    it("Retorna true se o componente está visível", () => {
+        cy.get('.style_container__33xI7').should('be.visible')
+        cy.get('.style_title__3ge6C').should('be.visible')
+        cy.get('.style_table__2MgqA').should('be.visible')
+        cy.get('.style_close__2Czx5').should('be.visible').wait(3000)
+    })
+    
+    it("Retorna true se o componente não está visível, após o item que o fecha ser clicado", () => {
+        cy.get('.style_close__2Czx5').click().wait(1000)
+        cy.get('.style_container__33xI7').should('not.be.visible')
+        cy.get('.style_title__3ge6C').should('not.be.visible')
+        cy.get('.style_table__2MgqA').should('not.be.visible')
+        cy.get('.style_close__2Czx5').should('not.be.visible').wait(2000)
+        
+    })
+})


### PR DESCRIPTION
- [x] Verificação se botão que dispara o componente está visível
- [x] Verificação ao clicar no botão que dispara o componente se torna visível
- [x] Verificação se o título está visível
- [x] Verificação se a lista de horários está visível
- [x] Verificação  se ao clicar no ícone de X o componente é fechado
- [x] Verificações se os elementos de fato não estão visíveis após click no item de fechamento do modalTimeListing. 


https://user-images.githubusercontent.com/50140771/132941634-f3302c09-3e78-4168-9312-c8b7c9962a82.mp4



